### PR TITLE
Add Tasker Widget control script

### DIFF
--- a/community/tasker-widget-control.lua
+++ b/community/tasker-widget-control.lua
@@ -1,0 +1,26 @@
+-- name = "Tasker Widget Control"
+-- description = "Add or Remove widgets from Tasker"
+-- data_source = "internal"
+-- type = "widget"
+-- author = "Sriram SV"
+-- version = "1.0"
+
+-- command structure 
+-- cmd:script:*:add=:=<widget_name>
+-- cmd:script:*:remove=:=<widget_name>
+-- adb shell am broadcast -a ru.execbit.aiolauncher.COMMAND --es cmd "script:tasker widget control:add=:=<widget_name>" --es password <password>
+-- adb shell am broadcast -a ru.execbit.aiolauncher.COMMAND --es cmd "script:tasker widget control:remove=:=<widget_name>" --es password <password>
+function on_command(cmd)
+    data = cmd:split("=:=")
+    command = data[1]
+    widget_name = data[2]
+    if command == "add" then
+        aio:add_widget(widget_name)
+    elseif command == "remove" then
+        aio:remove_widget(widget_name)
+    end
+end
+
+function on_alarm()
+    ui:show_text("Use tasker tasks to add/remove widgets")
+end


### PR DESCRIPTION
Adding a widget that can control adding/removing scripts from tasker tasks
This listens to broadcast intents from the tasker using the AIO launcher tasker API and adds or removes widgets on the home screen.

Few issues that I faced:
* Sending broadcast with script name set to `*` works, but using the widget name `tasker widget control` or `tasker-widget-control` didn't work
* I had found some widget names by trial and error e.g- using the widget name `news feed` or `news` or `newsfeed` didn't add or remove the news feed widget. Need help figuring those out