### PR TITLE
Search and navigate intent for google maps

### DIFF
--- a/community/maps-navigate.lua
+++ b/community/maps-navigate.lua
@@ -1,0 +1,31 @@
+-- name = "Navigate"
+-- description = "Navigate to address"
+-- data_source = "internal"
+-- type = "search"
+-- author = "Sriram SV"
+-- version = "1.0"
+
+text_from = ""
+text_to = ""
+maps_intent_action = "android.intent.action.VIEW"
+maps_intent_category = "android.intent.category.DEFAULT"
+maps_package_name = "com.google.android.apps.maps"
+
+local md_color = require "md_colors"
+local blue = md_colors.light_blue_800
+
+function on_search(input)
+    text_from = input
+    text_to = ""
+    search:show({..input},{blue})
+end
+
+function on_click(idx)
+    intent:start_activity{
+        action = maps_intent_action,
+        category = maps_intent_category,
+        package = maps_package_name,
+        data = "google.navigation:q="..text_from
+    }
+end
+


### PR DESCRIPTION
It might be useful to only run this for text which resembles a location.  However, it can currently run for any text input in the search bar

If AIO launcher has something like google ML kit entity extraction, it would be awesome to get context on the data and invoke certain scripts in the search bar.

[ML Kit Entity Extraction](https://github.com/googlesamples/mlkit/tree/master/android/entityextraction)