### PR TITLE
Add Google Fit Workout Shortcut

### DIFF
--- a/community/google-fit.lua
+++ b/community/google-fit.lua
@@ -1,0 +1,39 @@
+-- name = "Google Fit"
+-- description = "Start/Stop tracking workouts in google fit"
+-- data_source = "internal"
+-- type = "search"
+-- author = "Sriram SV"
+-- version = "1.0"
+-- prefix = "fit|track"
+
+fit_intent_action = "vnd.google.fitness.TRACK"
+fit_intent_mime_type = "vnd.google.fitness.activity/other"
+fit_intent_category = "android.intent.category.DEFAULT"
+fit_package_name = "com.google.android.apps.fitness"
+
+local md_color = require "md_colors"
+local blue = md_colors.light_blue_800
+local red = md_colors.red_800
+function on_search(input)
+    search:show({"Start Tracking", "Stop Tracking"},{blue,red})
+end
+
+function on_click(idx)
+    local status = ""
+    if idx == 1 then
+        status = "ActiveActionStatus"
+    elseif idx ==2 then
+        status = "CompletedActionStatus"
+    end
+    intent:start_activity{
+        action = fit_intent_action,
+        category = fit_intent_category,
+        package = fit_package_name,
+        type = fit_intent_mime_type,
+        extras = {
+            actionStatus=status
+        }
+    }
+end
+
+


### PR DESCRIPTION
I have not been able to fully test this due to some missing permissions on the AIO launcher side:
I get an error which says the following:

```
@/storage/emulated/0/Android/data/ru.execbit.aiolauncher/files/google-fit.lua:28 vm error: java.lang.SecurityException: Permission Denial: starting Intent { act=vnd.google.fitness.TRACK cat=[android.intent.category.DEFAULT] typ=vnd.google.fitness.activity/other pkg=com.google.android.apps.fitness cmp=com.google.android.apps.fitness/.shared.gateway.FitGateway (has extras) } from ProcessRecord{6b57e5d 4684:ru.execbit.aiolauncher/u0a11} (pid=4684, uid=10011) requires android.permission.START_VIEW_PERMISSION_USAGE
stack traceback:
	/storage/emulated/0/Android/data/ru.execbit.aiolauncher/files/google-fit.lua:28: in function </storage/emulated/0/Android/data/ru.execbit.aiolauncher/files/google-fit.lua:21>
	[Java]: in ?
```

It would be great If you can add that permission request in your manifest and let me know