### PR TITLE
fix duplicate birthday entries

### DIFF
--- a/community/birthdays-widget.lua
+++ b/community/birthdays-widget.lua
@@ -44,10 +44,19 @@ function redraw()
     events = {}
     local lines = {}
     for i,v in ipairs(contacts) do
-        table.insert(events, v)
-        table.insert(lines, fmt_line(v))
-        if i == prefs.count then
-            break
+	local fmt_out = fmt_line(v)
+	local insert = 0
+	if #lines == 0 then
+	    insert = 1
+	elseif not (fmt_out == lines[#lines]) then
+	    insert = 1
+	end
+	if insert == 1 then
+            table.insert(events, v)
+            table.insert(lines, fmt_out)
+            if #lines == prefs.count then
+                break
+            end
         end
     end
     ui:show_lines(lines)


### PR DESCRIPTION
Hello,

For some reason (multiple calendar sources with identical data?) sometimes you'd get a succession of duplicate entries for upcoming birthdays.
I updated the script's code to only show 1 line for each birthday (same date, same name).

PS: AIO Launcher is awesome, thank you for creating and maintaining it for so many years! 🙂